### PR TITLE
Add Aguara, Aguara MCP, and Oktsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[Oktsec](https://github.com/oktsec/oktsec)** - A security proxy for AI agent-to-agent communication. It provides Ed25519 identity verification, YAML-based policy enforcement, 169 detection rules aligned to the OWASP Top 10, and a full audit trail.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*
@@ -43,6 +44,8 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agentic Radar](https://github.com/splx-ai/agentic-radar)** - A static analysis tool that visualizes agent workflows (LangGraph, CrewAI, AutoGen). It detects risky tool usage, permission loops, and maps them to known vulnerabilities.
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
+- **[Aguara](https://github.com/garagon/aguara)** - A static security scanner for AI agent skills and MCP server configurations. It ships 148 detection rules across 13 categories, runs offline and deterministically with no LLM dependency.
+- **[Aguara MCP](https://github.com/garagon/aguara-mcp)** - An MCP server that exposes security scanning as a tool, letting AI agents analyze skills and configurations for threats before installing them.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
## Summary

Adds three open-source tools for securing autonomous AI agents:

- **[Aguara](https://github.com/garagon/aguara)** — Static security scanner for AI agent skills and MCP server configurations. 148 detection rules, 13 categories, offline, deterministic, no LLM. Added to **Static Analysis & Linters**.
- **[Aguara MCP](https://github.com/garagon/aguara-mcp)** — MCP server that exposes security scanning as a tool so AI agents can check skills before installing them. Added to **Static Analysis & Linters**.
- **[Oktsec](https://github.com/oktsec/oktsec)** — Security proxy for agent-to-agent communication with Ed25519 identity, policy enforcement, 169 detection rules (OWASP Top 10 aligned), and audit trail. Added to **Agent Firewalls & Gateways**.

All three projects are open-source, actively maintained, and follow the existing entry format.