### PR TITLE
Add AIP (Agent Identity Protocol) to Identity & Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AIP (Agent Identity Protocol)](https://github.com/The-Nexus-Guard/aip)** - Cryptographic identity and trust infrastructure for AI agents. Provides Ed25519-based DIDs, challenge-response verification, a trust network via vouching, and end-to-end encrypted messaging. Integrates with LangChain, CrewAI, and AutoGen via a one-line `ensure_identity()` call.
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
+- **[AIP (Agent Identity Protocol)](https://github.com/The-Nexus-Guard/aip)** - Cryptographic identity, trust, and encrypted messaging for AI agents. Ed25519 DIDs, vouch-chain trust, behavioral reliability scoring (PDR), W3C Verifiable Credentials, cross-protocol DID resolution (did:aip, did:key, did:web, did:aps). PyPI package + MCP server + REST API. 529 tests, 19 registered agents.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 ## 🆔 Identity & Authentication
 *Tools to manage agent identity (non-human identities).*
 
+- **[AIP (Agent Identity Protocol)](https://github.com/The-Nexus-Guard/aip)** - Cryptographic identity and trust infrastructure for AI agents. Provides Ed25519-based DIDs, challenge-response verification, a trust network via vouching, and end-to-end encrypted messaging. Integrates with LangChain, CrewAI, and AutoGen via a one-line `ensure_identity()` call.
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
 
 ---


### PR DESCRIPTION
Adding [AIP (Agent Identity Protocol)](https://github.com/The-Nexus-Guard/aip) to the Identity & Authentication section.

**What AIP does:**
- Cryptographic identity for AI agents using Ed25519 DIDs
- Vouch-chain trust networks between agents
- Behavioral reliability scoring (PDR)
- Encrypted agent-to-agent messaging
- W3C Verifiable Credentials for vouches
- Cross-protocol DID resolution (did:aip, did:key, did:web, did:aps)
- MCP server + REST API + CLI

**Why it fits Identity & Authentication:**
AIP gives AI agents cryptographic identities that are not tied to any platform. Agents register with Ed25519 key pairs, authenticate via challenge-response, build trust through signed vouches, and verify each other across protocols.

**Links:**
- [GitHub](https://github.com/The-Nexus-Guard/aip) | [PyPI](https://pypi.org/project/aip-identity/) | [Live API docs](https://aip-service.fly.dev/docs)
- 529 tests, 19 registered agents, MIT license