### PR TITLE
Add Aguara - static security scanner for AI agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 ## 🔍 Static Analysis & Linters
 *Tools to analyze agent configuration and logic code before deployment.*
 
+- **[Aguara](https://github.com/garagon/aguara)** - A static security scanner for AI agent skills and MCP server configurations. Detects prompt injection, credential leaks, data exfiltration, and supply-chain attacks with 173 built-in rules, 4 analysis layers, and remediation guidance.
 - **[Agentic Radar](https://github.com/splx-ai/agentic-radar)** - A static analysis tool that visualizes agent workflows (LangGraph, CrewAI, AutoGen). It detects risky tool usage, permission loops, and maps them to known vulnerabilities.
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.


### PR DESCRIPTION
Adds [Aguara](https://github.com/garagon/aguara) to the Static Analysis & Linters section.

Aguara is a static security scanner for AI agent skills and MCP servers. 173 detection rules, 4 analysis layers, remediation guidance. Go, Apache 2.0.