### PR TITLE
Add OneCLI — credential vault for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools to manage agent identity (non-human identities).*
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
+- **[OneCLI](https://github.com/onecli/onecli)** - Open-source credential vault for AI agents. A Rust HTTP gateway intercepts agent requests and injects API credentials transparently, so agents never handle raw keys. Supports per-agent scoped tokens and AES-256-GCM encryption at rest.
 
 ---
 


### PR DESCRIPTION
Adds [OneCLI](https://github.com/onecli/onecli) to the Identity & Authentication section.

OneCLI is an open-source credential vault for AI agents. A Rust HTTP gateway sits between agents and external APIs, intercepting requests and injecting credentials transparently. Agents get a proxy URL instead of raw keys.

- Apache 2.0 licensed
- AES-256-GCM encryption at rest
- Per-agent scoped access tokens
- Self-hosted via `docker compose up`