### PR TITLE
Add AgentVeil Protocol — trust enforcement for multi-agent systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools to manage agent identity (non-human identities).*
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
+- **[AgentVeil Protocol](https://agentveil.dev)** - A decentralized trust layer for multi-agent systems that provides cryptographic identity (W3C DID/Ed25519), multi-tier verification, and EigenTrust reputation across agent boundaries. Includes sybil-resistant attestations and an immutable IPFS-anchored audit trail for cross-organization accountability.
 
 ---
 


### PR DESCRIPTION
## What

Adds [AgentVeil Protocol](https://agentveil.dev) to the **Identity & Authentication** section.

## Why

AgentVeil is a trust enforcement layer for multi-agent systems:

- **Cryptographic identity** — W3C DID with Ed25519 key pairs
- **EigenTrust reputation** that works across agent owner boundaries
- **Sybil-resistant attestations** with collusion detection
- **Automated onboarding pipeline** — `@avp_tracked` decorator for zero-config integration
- **Immutable IPFS-anchored audit trail** for cross-organization accountability

Integrated with [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit/pull/1010) as official TrustProvider.

https://agentveil.dev