### PR TITLE
Add Agent Passport System to Identity & Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools to manage agent identity (non-human identities).*
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
+- **[Agent Passport System](https://github.com/aeoess/agent-passport-system)** - Open protocol for AI agent identity, scoped delegation, and enforcement. Ed25519 cryptographic identity, delegation chains with monotonic narrowing, 3-signature action chain (intent → policy evaluation → receipt), 4-gate commerce authorization, cascade revocation, Values Floor governance, and Merkle-committed audit settlements. 103 modules, 2,000+ tests. Apache-2.0. `npm install agent-passport-system`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools to manage agent identity (non-human identities).*
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
-- **[Agent Passport System](https://github.com/aeoess/agent-passport-system)** - Open protocol for AI agent identity, scoped delegation, and enforcement. Ed25519 cryptographic identity, delegation chains with monotonic narrowing, 3-signature action chain (intent → policy evaluation → receipt), 4-gate commerce authorization, cascade revocation, Values Floor governance, and Merkle-committed audit settlements. 103 modules, 2,000+ tests. Apache-2.0. `npm install agent-passport-system`
+- **[Agent Passport System](https://github.com/aeoess/agent-passport-system)** - Open Apache-2.0 protocol for AI agent identity, scoped delegation, and enforcement. Provides Ed25519 agent passports, delegation chains that narrow monotonically across scope, spend, depth, time, reputation, values, and reversibility, and signed action receipts evaluated at an enforcement boundary. Specified in IETF Internet-Draft draft-pidlisnyi-aps-03, with byte-level conformance vectors published separately. TypeScript and Python reference implementations on npm and PyPI.
 
 ---
 


### PR DESCRIPTION
Adds [Agent Passport System](https://github.com/aeoess/agent-passport-system) to the Identity & Authentication section.

APS is an open protocol for AI agent identity, scoped delegation, and enforcement:

- **Ed25519 cryptographic identity** with passport grades (0-3)
- **Delegation chains** with monotonic narrowing (authority can only decrease)
- **3-signature action chain**: intent → policy evaluation → execution receipt
- **4-gate commerce authorization**: passport, scope, spend limit, merchant allowlist
- **Cascade revocation** — revoking parent invalidates all children
- **Values Floor** governance with 7 attested principles
- **Merkle-committed settlements** for tamper-evident audit trails
- **GDPR Art. 30 / EU AI Act Art. 10 compliance evidence export**

103 modules, 2,000+ tests. Apache-2.0.

Available on npm (`agent-passport-system`), PyPI (`agent-passport-system`), and as an MCP server (`agent-passport-system-mcp`).

Referenced in OWASP Agentic Top 10 threads (#802, #812, #817), A2A protocol discussions, and Microsoft AGT (merged PR #598).