### PR TITLE
feat: add Prismor / immunity-agent — runtime security monitor for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[Prismor / immunity-agent](https://github.com/PrismorSec/immunity-agent)** - A local runtime security monitor for AI coding agents (Claude Code, Cursor, Windsurf). It hooks into agent tool-use pipelines before commands reach the OS, evaluating them against YAML-configurable policies to block dangerous actions, secret exfiltration, privilege escalation, and prompt injection — with session audit logs and an MCP/skill scanner.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*
 
 - **[Strix](https://github.com/usestrix/strix)** - An autonomous AI agent designed for penetration testing. It runs inside a docker sandbox to actively probe applications and generate verified exploit capabilities.
-- **[PyRIT](https://github.com/Azure/PyRIT)** - Microsoft’s open-source red teaming framework for generative AI. It automates multi-turn adversarial attacks to test if an agent can be coerced into harmful behavior.
+- **[PyRIT](https://github.com/Azure/PyRIT)** - Microsoft's open-source red teaming framework for generative AI. It automates multi-turn adversarial attacks to test if an agent can be coerced into harmful behavior.
 - **[Agentic Security](https://github.com/msoedov/agentic_security)** - A dedicated vulnerability scanner for agent workflows and LLMs capable of running multi-step jailbreaks and fuzzing attacks against agent logic.
 - **[Garak](https://github.com/leondz/garak)** - The "Nmap for LLMs." A vulnerability scanner that probes models for hallucination, data leakage, and prompt injection susceptibilities.
 - **[A2A Scanner](https://github.com/cisco-ai-defense/a2a-scanner)** - A scanner by Cisco designed to inspect "Agent-to-Agent" communication protocols for threats, validating agent identities and ensuring compliance with communication specs.
@@ -55,7 +56,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 ## 🚧 Guardrails & Compliance
 *Middleware to enforce business logic and safety policies on inputs and outputs.*
 
-- **[NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** - NVIDIA’s toolkit for adding programmable rails to LLM-based apps. It ensures agents stay on topic, avoid jailbreaks, and adhere to defined safety policies.
+- **[NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** - NVIDIA's toolkit for adding programmable rails to LLM-based apps. It ensures agents stay on topic, avoid jailbreaks, and adhere to defined safety policies.
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 


### PR DESCRIPTION
## What this adds

- **[Prismor / immunity-agent](https://github.com/PrismorSec/immunity-agent)** added to the **🛡️ Agent Firewalls & Gateways (Runtime Protection)** section.

## Why it fits

Prismor is an open-source runtime security monitor purpose-built for AI coding agents (Claude Code, Cursor, Windsurf). It operates at the **agent hook layer** — before commands reach the OS — which is exactly the gap this list's Runtime Protection section covers.

Key capabilities:
- Hooks into `PreToolUse`/`PostToolUse` pipelines to evaluate every tool call against YAML-configurable policies
- Blocks dangerous actions: destructive commands, secret exfiltration, privilege escalation, reverse shells, prompt injection, supply chain attacks (35+ rules)
- Secret cloaking layer (`@@SECRET:name@@` placeholders substituted at execution time, scrubbed from output)
- MCP server & skill scanner — detects exfiltration endpoints, encoded payloads, shell injection in installed skills
- Session audit log (JSONL + SQLite) for full replay of what the agent did
- Network egress allowlist and isolation rules

Repo is actively maintained with recent commits.