### PR TITLE
Add PromptTrace - free prompt injection training platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Garak](https://github.com/leondz/garak)** - The "Nmap for LLMs." A vulnerability scanner that probes models for hallucination, data leakage, and prompt injection susceptibilities.
 - **[A2A Scanner](https://github.com/cisco-ai-defense/a2a-scanner)** - A scanner by Cisco designed to inspect "Agent-to-Agent" communication protocols for threats, validating agent identities and ensuring compliance with communication specs.
 - **[Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai)** - A framework for building specialized security agents for offensive and defensive operations, often used in CTF (Capture The Flag) scenarios.
+- **[PromptTrace](https://prompttrace.airedlab.com)** - Free hands-on AI security training platform. Practice prompt injection, RAG poisoning, and tool exploitation against real LLMs with full prompt stack visibility. Includes 10 labs, a 15-level CTF (The Gauntlet), and 9 learning modules aligned with OWASP Top 10 for LLMs.
 
 ## 🔍 Static Analysis & Linters
 *Tools to analyze agent configuration and logic code before deployment.*


### PR DESCRIPTION
[PromptTrace](https://prompttrace.airedlab.com) is a free, hands-on AI security training platform for practicing prompt injection, RAG poisoning, and tool exploitation against real LLMs.

**Why it fits here:**
- Fits in "Red Teaming & Vulnerability Scanners" as a hands-on training platform for AI agent security red teaming

**Key features:**
- 10 attack labs covering direct injection, RAG poisoning, tool abuse, defense bypass, and agentic attacks
- 15-level CTF challenge (The Gauntlet) with progressively harder AI defenses
- Context Trace: real-time visualization of the complete prompt stack (system prompt, RAG docs, tool definitions, user input)
- 9 learning modules from fundamentals to advanced
- Aligned with OWASP Top 10 for LLM Applications and OWASP Top 10 for Agentic AI
- 100% free, no paid tiers