### PR TITLE
Add LLM Safe Haven — runtime protection for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[LLM Safe Haven](https://github.com/pleasedodisturb/llm-safe-haven)** - Security toolkit for AI coding agents. `npx llm-safe-haven` auto-detects 14 agents (Claude Code, Cursor, Windsurf, Copilot, Aider, etc.), installs fail-closed PreToolUse/PostToolUse hooks (bash firewall, secret guard, audit logger), and scores security posture Level 0-4. Zero dependencies. Also includes a threat model with 26+ real incidents and hardening guides for 6 agents.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds [LLM Safe Haven](https://github.com/pleasedodisturb/llm-safe-haven) to the Agent Firewalls & Gateways section.

- `npx llm-safe-haven` — auto-detects 14 agents, installs fail-closed hooks, scores posture
- PreToolUse hooks: bash firewall (blocks exfiltration, destructive commands), secret guard (blocks credential writes)
- PostToolUse hooks: JSONL audit logger
- Zero dependencies, 27 kB, published on npm
- Also includes threat model (26+ incidents), 6 hardening guides, 64+ references