### PR TITLE
Add Mira to runtime protection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[Mira](https://github.com/vwww-droid/Mira)** - Runtime protection analysis platform for third-party Android and iOS apps, enabling AI to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
## Summary
Add Mira to the Agent Firewalls & Gateways (Runtime Protection) section.

## Why
Mira is an Android and iOS runtime protection analysis platform for third-party target apps. It enables AI to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.

## Project
- Repo: https://github.com/vwww-droid/Mira

## Notes
- Formatting matches existing entries.
- Entry is placed directly after the last existing item in the section.
