### PR TITLE
Add Intaris to agent runtime protection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools that sit between the agent and the world to filter traffic, prevent unauthorized tool access, and block prompt injections.*
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
+- **[Intaris](https://github.com/fpytloun/intaris)** - An MCP proxy with guardrails for AI agents, evaluating tool-call intent and actions before execution and routing risky operations through policy and approval controls.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners


### PR DESCRIPTION
Adds Intaris as an MCP proxy with guardrails for AI agents in the Agent Firewalls & Gateways section.