### PR TITLE
Add Armorer Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools that sit between the agent and the world to filter traffic, prevent unauthorized tool access, and block prompt injections.*
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
+- **[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)** - A local Rust scanner for AI-agent prompt injection, credential redaction, sensitive-data requests, exfiltration-style text, and dangerous tool-call context. It returns structured JSON verdicts for runtime enforcement.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners


### PR DESCRIPTION
Adds Armorer Guard, a local Rust scanner for AI-agent prompt injection, credential redaction, sensitive-data requests, exfiltration-style text, and dangerous tool-call context.\n\nRepo: https://github.com/ArmorerLabs/Armorer-Guard\nDemo: https://huggingface.co/spaces/armorer-labs/armorer-guard-demo