### PR TITLE
Add Armorer Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)** - A local Rust scanner for prompts, tool-call arguments, MCP results, credentials, and exfiltration risk, returning machine-readable reasons for pre-tool-call or post-tool-result enforcement.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds Armorer Guard under agent firewalls and runtime protection. It is an open-source local Rust scanner for prompts, tool-call arguments, MCP results, credentials, and exfiltration risk, returning machine-readable reasons suitable for pre-tool-call or post-tool-result enforcement.