### PR TITLE
Add AI Change Passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - [Static Analysis & Linters](#-static-analysis--linters)
 - [Sandboxing & Isolation Environments](#-sandboxing--isolation-environments)
 - [Guardrails & Compliance](#-guardrails--compliance)
+- [Governance & Provenance](#-governance--provenance)
 - [Benchmarks & Datasets](#-benchmarks--datasets)
 - [Identity & Authentication](#-identity--authentication)
 - [Contributing](#-contributing)
@@ -58,6 +59,11 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** - NVIDIA’s toolkit for adding programmable rails to LLM-based apps. It ensures agents stay on topic, avoid jailbreaks, and adhere to defined safety policies.
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
+
+## Governance & Provenance
+*Tools that create audit records, provenance metadata, or review evidence for agent-assisted work.*
+
+- **[AI Change Passport](https://github.com/P-r-e-m-i-u-m/ai-change-passport)** - A GitHub Action and CLI that creates signed provenance reports for AI-assisted pull requests, including sensitive file touches, dependency changes, workflow changes, test signals, risk scoring, and human approval guidance.
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
Adds AI Change Passport under a new Governance & Provenance section.\n\nIt is an open-source GitHub Action and CLI that creates signed provenance reports for AI-assisted pull requests, including sensitive file touches, dependency/workflow changes, test signals, risk scoring, and human approval guidance.