### PR TITLE
Add APort to agent runtime security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[APort](https://www.aport.ai/)** - Runtime security layer for AI agents that enforces tool-use policies, isolates risky execution, and records auditable agent actions.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
## Summary
- Adds APort to the Agent Firewalls & Gateways section.
- Places it with other agent runtime/security controls where the tool category matches the list.

## Verification
- Checked the README for an existing APort entry before editing.
- Confirmed the change is a single README entry in the relevant section/table.

Related bounty: https://github.com/aporthq/aport-integrations/issues/19

## Payment details
PayPal: https://paypal.me/Jeremytsangchina  
USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y