### PR TITLE
Add MartinLoop to runtime protection list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[MartinLoop](https://github.com/Keesan12/martin-loop)** - Open-source control plane for AI coding agents that enforces budget caps, verifier gates, explicit halt reasons, and inspectable run records before loops drift or overspend.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
## Summary
- add MartinLoop under Agent Firewalls & Gateways (Runtime Protection)

## Why
MartinLoop sits in the runtime control layer around autonomous coding agents: budget caps, verifier gates, explicit halt reasons, and run records that help prevent unsafe or wasteful looping behavior.
