### PR TITLE
Add SkilLock under Static Analysis & Linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agentic Radar](https://github.com/splx-ai/agentic-radar)** - A static analysis tool that visualizes agent workflows (LangGraph, CrewAI, AutoGen). It detects risky tool usage, permission loops, and maps them to known vulnerabilities.
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
+- **[SkilLock](https://github.com/skills-lock/skil-lock)** - A lockfile + GitHub Action that pins the parsed behavior surface (shell commands, URLs, file reads) of Claude Code and Codex agent skills. Catches drift between PRs that hash pinning misses; emits SARIF for GitHub Code Scanning. Apache 2.0.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
Adds SkilLock under "Static Analysis & Linters."

SkilLock is an Apache 2.0 Go binary + GitHub Action that parses every SKILL.md in a repo, extracts the capability surface (shell commands, network URLs, file reads/writes, allowed tools, bundled scripts), commits it as `skills.lock`, and runs a capability-delta diff on every PR. Catches the family of "SKILL.md legitimately changed and now does something different" cases that hash pinning misses.

**Maintenance check (per CONTRIBUTING):**

- Initial commit on 2026-05-13, public since 2026-05-20.
- v0.1.0 released 2026-05-20, v0.1.2 released 2026-05-23. Last commit within the last week.
- Marketplace listing live: https://github.com/marketplace/actions/skillock-ci

**Scope fit (per CONTRIBUTING):**

- Open source (Apache 2.0).
- Directly related to securing AI agents: skills are the capability-grant mechanism for Claude Code / Codex agents.
- Static-analysis category fit: detection is grep + parsed tokens, deterministic, no LLM-in-the-loop, auditable in CI.

**Wedge vs adjacent tools in the list:**

- *Agentic Radar* visualizes workflow graphs. SkilLock pins behavior to a lockfile and diffs it on PRs - same family, different artifact.
- *Agent Bound* measures entropy at design-time. SkilLock catches drift at PR-time.

**Links:**

- Repo: https://github.com/skills-lock/skil-lock
- Worked example with real BLOCK on drift branch: https://github.com/skills-lock/example-claude-code-skills
- File-format spec (CC BY 4.0): https://github.com/skills-lock/skil-lock/blob/main/SPEC.md