### PR TITLE
Add Tuning Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[Tuning Engines](https://www.tuningengines.com/)** - A compliance, control, and cost action plane for production AI traffic. It provides governed OpenAI-compatible inference, agent/MCP/skill registries, policy and guardrail enforcement, approvals, traces, usage reporting, and CLI support.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
This adds Tuning Engines to the Agent Firewalls & Gateways section.\n\nWhy it may fit:\n- It provides a governed OpenAI-compatible control point for production AI traffic.\n- The security angle is runtime policy/guardrail enforcement, approvals, traces, usage reporting, and agent/MCP/skill registry controls.\n- It is most relevant to the runtime protection and governance parts of the agent security lifecycle.\n\nHappy to adjust placement or wording if another section fits better.