### PR TITLE
feat: add TWZRD Agent Intel to Identity & Authentication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools to manage agent identity (non-human identities).*
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - On-chain trust scoring and reputation verification for AI agent wallets on Solana. Provides MCP tools (`score_agent`, `preflight_check`) for querying verifiable wallet reputation before authorizing agent actions, and signed trust receipts via x402 micropayments. Prevents agent impersonation attacks in multi-agent systems.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Identity & Authentication** section.

**What it does**: On-chain trust scoring and reputation verification for AI agent wallets on Solana. Provides verifiable wallet reputation before authorizing agent-to-agent actions — preventing AI agent impersonation attacks.

**MCP Tools** (free):
- `score_agent(wallet)` — returns trust score, behavioral flags, and on-chain history
- `preflight_check(wallet)` — binary go/no-go for agent authorization

**Paid tool**: `get_trust_receipt(wallet)` — returns a signed, on-chain-verifiable trust receipt via x402 micropayment

**Relevance**: This fills a gap in the Identity & Authentication section — it addresses *agent wallet identity* (non-human identity) specifically for multi-agent autonomous systems, where wallet reputation is the trust anchor, not a username/password or PKI cert. Designed to be called by agents before executing a high-value action with a counterpart agent.

**Config**:
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

🤖 Submitted via Claude Code