### PR TITLE
Add API Relay Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[PyRIT](https://github.com/Azure/PyRIT)** - Microsoft’s open-source red teaming framework for generative AI. It automates multi-turn adversarial attacks to test if an agent can be coerced into harmful behavior.
 - **[Agentic Security](https://github.com/msoedov/agentic_security)** - A dedicated vulnerability scanner for agent workflows and LLMs capable of running multi-step jailbreaks and fuzzing attacks against agent logic.
 - **[Garak](https://github.com/leondz/garak)** - The "Nmap for LLMs." A vulnerability scanner that probes models for hallucination, data leakage, and prompt injection susceptibilities.
+- **[API Relay Audit](https://github.com/toby-bridges/api-relay-audit)** - A local 14-step audit tool for AI API relays and LLM proxies that checks prompt injection, model substitution, tool-call rewriting, error leakage, SSE anomalies, and Web3 wallet risks.
 - **[A2A Scanner](https://github.com/cisco-ai-defense/a2a-scanner)** - A scanner by Cisco designed to inspect "Agent-to-Agent" communication protocols for threats, validating agent identities and ensuring compliance with communication specs.
 - **[Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai)** - A framework for building specialized security agents for offensive and defensive operations, often used in CTF (Capture The Flag) scenarios.
 


### PR DESCRIPTION
Adds API Relay Audit to the Red Teaming & Vulnerability Scanners section. It is a local 14-step audit tool for AI API relays and LLM proxies, covering prompt injection, model substitution, tool-call rewriting, error leakage, SSE anomalies, and Web3 wallet-risk probes.