### PR TITLE
Add Assay to Agent Firewalls & Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools that sit between the agent and the world to filter traffic, prevent unauthorized tool access, and block prompt injections.*
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
+- **[Assay](https://github.com/Rul1an/assay)** - Policy-as-code for MCP: a fail-closed proxy that denies risky tool calls before they run, emits offline-verifiable evidence bundles of what executed, and enforces IPv4/TCP egress in-kernel via eBPF/LSM and Landlock on Linux. Rust, MIT.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
 


### PR DESCRIPTION
Adds [Assay](https://github.com/Rul1an/assay) to **Agent Firewalls & Gateways (Runtime Protection)**, alphabetically after AgentGateway. It sits between the agent and the world exactly as the section describes.

Assay is policy-as-code for MCP: a fail-closed proxy that denies risky tool calls before they run, produces offline-verifiable evidence bundles of what actually executed, and enforces IPv4/TCP egress in-kernel via eBPF/LSM and Landlock on Linux. Rust, MIT, offline-first.

Entry kept to one line in the section format. It's deliberately bounded: a gate and an evidence layer, not a prompt-injection or tool-poisoning scanner and not a trust score. Thanks for curating this!