### PR TITLE
Add fak (Fused Agent Kernel) to Agent Firewalls & Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[fak (Fused Agent Kernel)](https://github.com/anthony-chaudhary/fak)** - A single Go binary that sits between an agent and its tools and adjudicates every tool call on the same call path before it runs: a default-deny capability gate the model can't talk past, plus a quarantine that holds suspicious tool results out of the model's context to contain prompt injection and tool poisoning. Apache-2.0.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds **[fak](https://github.com/anthony-chaudhary/fak)** to the *Agent Firewalls & Gateways (Runtime Protection)* section.

fak is an open-source (Apache-2.0) Go "agent kernel": a single binary that sits between an AI agent and its tools and adjudicates every tool call **on the same call path** before it runs — a default-deny capability gate the model can't talk past (no IPC, fails closed), plus a quarantine that holds suspicious tool results out of the model's context to contain prompt injection and tool poisoning. That's a direct match for this section's framing ("tools that sit between the agent and the world to filter traffic, prevent unauthorized tool access, and block prompt injections").

Checklist against the contribution guidelines:
- ✅ Directly autonomous-AI-agent security (a runtime gate on agent tool calls).
- ✅ Open-source, Apache-2.0.
- ✅ Maintained — active in the last 12 months (released v0.30.0 this month).
- ✅ Not a duplicate; entry follows the section format (bold link, description ending with a period), appended in order.

In the interest of honesty (which the project takes seriously — it ships a machine-checked claims ledger), the result *detector* is evadable by design; the security floor is the capability lock plus the containment, which an attacker has to beat as two independent gates rather than fooling one classifier.