### PR TITLE
Add Armorer Guard to agent runtime protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard)** - Local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments before execution.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners


### PR DESCRIPTION
Adds Armorer Guard to Agent Firewalls & Gateways. I maintain Armorer Guard at Armorer Labs; it is an MIT-licensed local Rust scanner/MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments before execution.