### PR TITLE
Add Audit & Accountability category with Nobulex

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - [Guardrails & Compliance](#-guardrails--compliance)
 - [Benchmarks & Datasets](#-benchmarks--datasets)
 - [Identity & Authentication](#-identity--authentication)
+- [Audit & Accountability](#-audit--accountability)
 - [Contributing](#-contributing)
 
 ---
@@ -72,6 +73,11 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
 - **[OneCLI](https://github.com/onecli/onecli)** - Open-source credential vault for AI agents. A Rust HTTP gateway intercepts agent requests and injects API credentials transparently, so agents never handle raw keys. Supports per-agent scoped tokens and AES-256-GCM encryption at rest.
+
+## 📜 Audit & Accountability
+*Tools that produce tamper-evident records of what an AI agent actually did, verifiable by third parties without trusting the operator.*
+
+- **[Nobulex](https://github.com/arian-gogani/nobulex)** - Open-source cryptographic receipt layer for agent tool invocations. Emits Ed25519-signed bilateral receipts (pre-execution admission + post-execution outcome) linked by a content-derived `action_ref` over JCS-canonical bytes (RFC 8785). Independently verifiable against the agent's published public key; cited in OWASP CheatSheetSeries, Microsoft Agent Governance Toolkit, and x402 settlement-receipt extension. MIT licensed.
 
 ---
 


### PR DESCRIPTION
Propose adding a new **Audit & Accountability** category to capture a class of agent security tools the current list doesn't cover: post-action cryptographic evidence verifiable by third parties without trusting the operator.

This is distinct from Guardrails (pre-action enforcement), Identity (who the agent is), and Observability (operator-facing telemetry). The category exists in the security stack because operator-controlled audit logs don't survive adversarial review — they can be edited, deleted, or fabricated. Cryptographic receipts give a verifier a signed artifact that can be checked against the agent's published public key offline.

EU AI Act Article 12 enforcement (August 2, 2026) makes this category practically mandatory for high-risk AI deployments.

**Adds:**
- New top-level section `📜 Audit & Accountability`
- Single entry: [Nobulex](https://github.com/arian-gogani/nobulex) — open-source receipt SDK, MIT licensed, cited in OWASP CheatSheetSeries, x402 (PR #2666 §5), and Microsoft AGT ecosystem

The category is intentionally extensible: there are at least 6-8 independent implementations of the same receipt pattern in active development (Vaara, argentum-core, AgentOracle+AgentTrust, agent-guard, VeritasActa, AlgoVoi, Nobulex). Listing one here seeds the section; others can be added as they mature.

Happy to revise per maintainer feedback if a different placement or shape is preferred.