### PR TITLE
Add rust-norion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[rust-norion](https://github.com/yanghao1143/rust-norion)** - Rust research prototype for an AI inference control layer, with runtime boundaries around model/tool routing, memory writes, evidence gates, rollback, and audit traces.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds rust-norion to Agent Firewalls & Gateways (Runtime Protection).

Why this fits:
- open-source Rust project focused on the control layer around AI/LLM runtimes;
- relevant security surface includes model/tool routing, memory-write boundaries, evidence gates, rollback, and audit traces;
- described as a research prototype, not a production security gateway.

I searched the list first and did not find an existing rust-norion entry.