### PR TITLE
Add Adrian (open-source runtime AI agent security) to Runtime Protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[Adrian](https://github.com/secureagentics/Adrian)** - Open-source, AARM-aligned runtime security engine that monitors AI agents' tool calls and reasoning traces, then blocks malicious tool use, prompt injection, and out-of-remit actions in-flight (audit or block mode). Two-line LangChain/LangGraph install; fully self-hostable offline. Apache-2.0.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds **Adrian** under *Agent Firewalls & Gateways (Runtime Protection)*.

Adrian is an open-source, AARM-aligned runtime security engine for AI agents — it analyses tool calls and reasoning traces and can block prompt injection and unsafe / out-of-remit tool use in-flight (audit or block mode). Python (LangChain/LangGraph) and TypeScript SDKs, fully self-hostable offline, Apache-2.0. Actively maintained (commits this month).

Follows the contribution guidelines (open source, runtime protection scope, recently maintained) and the `- **[Name](url)** - description.` format.

**Disclosure:** I'm a maintainer (Secure Agentics) — happy to adjust wording or placement to house style.
