### PR TITLE
Add SecuredAI to Guardrails & Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
+- **[SecuredAI](https://securedai.com/)** - Client-side prompt DLP middleware that detects and masks PII/PHI on inputs before they reach the model (OpenAI/DeepSeek) and restores the originals locally via a zero-knowledge vault, so sensitive data never leaves the environment.
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
Adds **SecuredAI** (https://securedai.com) under *Guardrails & Compliance*.

Input/output middleware that detects and masks PII/PHI in prompts before they reach the model (OpenAI/DeepSeek), then restores originals locally via a zero-knowledge vault. Same "must not contain PII" role as the existing Guardrails entry, applied at the prompt boundary.

Single-line addition, format matches the section. Thanks for the list.