### PR TITLE
Add Project Telos agent security tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
+- **[Project Telos](https://github.com/HarperZ9/telos)** - Open-source MCP/CLI workbench for auditing agent-assisted work with source receipts, workspace maps, action ledgers, CI triage, and reviewable verification packets.
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
Adds Project Telos to this AI agent security list as a local-first MCP/CLI workbench for inspectable AI-assisted development and operations.

Project Telos exposes source-checkout MCP surfaces and local verification workflows for source provenance, workspace maps, routing ledgers, action receipts, context packs, CI/operator doctors, and MATCH/DRIFT/UNVERIFIABLE review packets.

Validation:
- git diff --check
- rg Project Telos / HarperZ9/telos in README.md
- Native Telos operator doctor in this outreach session reports MATCH, 14/14 checks, and 70 available MCP tools across Gather, Index, Forum, Crucible, and Telos.
