### PR TITLE
Add IronClaw to Sandboxing & Isolation Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)** - A Kubernetes Native project providing a Sandbox Custom Resource Definition (CRD) to manage isolated, stateful workloads for AI agents.
 - **[Agent-Infra Sandbox](https://github.com/agent-infra/sandbox)** - An "All-In-One" sandbox combining Browser, Shell, VSCode, and File System access in a single Docker container, optimized for agentic tasks.
 - **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** - Formerly OpenDevin, this platform includes a secure runtime environment for autonomous coding agents to operate without accessing the host machine's sensitive files.
+- **[IronClaw](https://github.com/IronSecCo/ironclaw)** - A security-hardened runtime that isolates AI agent tool-calls in gVisor, adding a human approval gateway, encrypted task queues, and a signed, attested supply chain (cosign, SBOM, SLSA). Open source under AGPL-3.0.
 
 ## 🚧 Guardrails & Compliance
 *Middleware to enforce business logic and safety policies on inputs and outputs.*


### PR DESCRIPTION
Adds **IronClaw** (https://github.com/IronSecCo/ironclaw) under **Sandboxing & Isolation Environments**.

IronClaw is an open-source (AGPL-3.0) security-hardened runtime that isolates AI agent tool-calls in gVisor. It adds a human approval gateway, encrypted task queues, and a signed, attested supply chain (cosign, SBOM, SLSA provenance).

- Single entry, correct section, bold-link format matching existing entries.
- Follows CONTRIBUTING (fork, feature branch, PR).

Thanks for maintaining this list.