### PR TITLE
Add Nika to Sandboxing & Isolation Environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)** - A Kubernetes Native project providing a Sandbox Custom Resource Definition (CRD) to manage isolated, stateful workloads for AI agents.
 - **[Agent-Infra Sandbox](https://github.com/agent-infra/sandbox)** - An "All-In-One" sandbox combining Browser, Shell, VSCode, and File System access in a single Docker container, optimized for agentic tasks.
 - **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** - Formerly OpenDevin, this platform includes a secure runtime environment for autonomous coding agents to operate without accessing the host machine's sensitive files.
+- **[Nika](https://github.com/supernovae-st/nika)** - Rust workflow engine that runs AI tasks under default-deny permits (file/network/exec/tool allowlists) with pre-run static secret-flow checks and hash-chained tamper-evident run traces (`nika trace verify`) for post-hoc audit.
 
 ## 🚧 Guardrails & Compliance
 *Middleware to enforce business logic and safety policies on inputs and outputs.*


### PR DESCRIPTION
One entry in Sandboxing & Isolation Environments (house format: bold link, dash, description). Nika is an open-source (AGPL) Rust workflow engine that runs AI tasks under default-deny permits — file/network/exec/tool allowlists, with the tightest boundary machine-generated by --infer-permits — plus pre-run static secret-flow checks and hash-chained tamper-evident run traces (nika trace verify) for post-hoc audit. Permission-controlled execution like the SandboxAI neighbor, at the workflow layer rather than the container layer. Only shipped features claimed. Disclosure: I am the author (first-party submission).