### PR TITLE
Add gate.cat runtime veto layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[gate.cat](https://github.com/BGMLAI/gate.cat)** - An open-source deterministic runtime veto layer that blocks known destructive filesystem, cloud, database, identity, billing, and secret-exfiltration actions before an agent executes them.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners


### PR DESCRIPTION
## Summary

Adds gate.cat to the Agent Firewalls & Gateways section.

It is directly in scope as an Apache-2.0 runtime protection layer for autonomous agents: deterministic pre-execution policy vetoes through a Claude Code hook, gated shell, SDK, and OpenAI-compatible tool-call proxy.

The entry follows the requested one-line format and ends with a period.
