### PR TITLE
Add gate.cat to agent firewalls and gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
+- **[gate.cat](https://github.com/BGMLAI/gate.cat)** - An Apache-2.0, local deterministic action veto for coding agents that blocks destructive shell, cloud, database, and repository commands before execution.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners


### PR DESCRIPTION
## Summary

Adds gate.cat to **Agent Firewalls & Gateways (Runtime Protection)**.

It is an Apache-2.0, actively maintained, local deterministic veto that runs before coding-agent actions and blocks named destructive command classes. The entry follows the repository's requested one-line format and makes no performance or adoption claims.

Disclosure: I maintain gate.cat.

## Checks

- Searched the current list; gate.cat is not already present.
- Repository is public and active: https://github.com/BGMLAI/gate.cat
- Link returns HTTP 200.
- `git diff --check` passes.
