### PR TITLE
Add SourceryKit to Agent Firewalls & Gateways (Runtime Protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[SourceryKit](https://github.com/ProvablyAI/sourcerykit)** - A Python SDK that verifies an agent's outbound requests against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. It hooks into the HTTP libraries to enforce this, logging each outbound call and blocking anything not on a trusted-endpoint allow-list, including MCP handoffs.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Hey, opened this to suggest adding SourceryKit to the Agent Firewalls & Gateways (Runtime Protection) section.

I work with Provably, who builds it. It's a Python SDK (source-available, BSL 1.1) that verifies an agent's outbound requests against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. It hooks into the HTTP libraries to do this, logging each outbound call and blocking anything not on a trusted-endpoint allow-list, and it covers MCP handoffs too. It sits in the same runtime-protection spot as the gateways already listed there.

I added one entry at the end of that section, in your format. Thanks for taking a look.
