### PR TITLE
Add mcp-defense-bench (MCP security defense-coverage benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Resources to evaluate agent security performance.*
 
 - **[CVE Bench](https://github.com/uiuc-kang-lab/cve-bench)** - A benchmark for evaluating an AI agent's ability to exploit real-world web application vulnerabilities (useful for testing defensive agents).
+- **[mcp-defense-bench](https://github.com/Gowthaman90/mcp-defense-bench)** - Vendor-neutral benchmark measuring how much of the Model Context Protocol (MCP) attack surface a defensive proxy/gateway/scanner covers (22–24 vectors), crosswalked to NIST AI RMF and the OWASP LLM/Agentic Top 10; ships fixtures, tool adapters, a live leaderboard, and a citable DOI.
 
 ## 🆔 Identity & Authentication
 *Tools to manage agent identity (non-human identities).*


### PR DESCRIPTION
Adds mcp-defense-bench — a vendor-neutral benchmark measuring how much of the MCP (Model Context Protocol) attack surface a defensive proxy/gateway/scanner covers (22–24 vectors), crosswalked to NIST AI RMF and the OWASP LLM/Agentic Top 10. Ships test fixtures, tool adapters, a live leaderboard, and a citable DOI (10.5281/zenodo.21346206). Repo: https://github.com/Gowthaman90/mcp-defense-bench. Entry placed in the benchmarks section following the existing format.