### PR TITLE
Add Agent Commerce Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 ## 🚧 Guardrails & Compliance
 *Middleware to enforce business logic and safety policies on inputs and outputs.*
 
+- **[Agent Commerce Guard](https://agent-commerce-guard.vercel.app/)** - A hosted policy guardrail that scores autonomous-agent actions involving wallet spend, deployments, destructive commands, token launches, social posts, and credential access before execution, with a free sanitized evaluator and optional x402-paid API and package.
 - **[NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** - NVIDIA's toolkit for adding programmable rails to LLM-based apps. It ensures agents stay on topic, avoid jailbreaks, and adhere to defined safety policies.
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.


### PR DESCRIPTION
## Summary

- add Agent Commerce Guard to Guardrails & Compliance
- describe its autonomous-agent action policy coverage
- disclose the free sanitized evaluator and optional x402-paid API/package

## Validation

- product page returns HTTP 200
- free demo evaluator returns HTTP 200
- entry follows the documented one-line format
- no existing entry, issue, or pull request matched Agent Commerce Guard