### PR TITLE
Add gate.cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[gate.cat](https://github.com/BGMLAI/gate.cat)** - A deterministic, fail-closed action veto for AI coding agents that blocks irreversible shell commands (e.g. `rm -rf`, `DROP TABLE`, `terraform destroy`, secret exfiltration) before they run. Uses no LLM in the veto path (prompt injection cannot route around it) and integrates as a Claude Code PreToolUse hook, a gated shell, or a local OpenAI-API proxy.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds **gate.cat** to the **Agent Firewalls & Gateways (Runtime Protection)** section.

Disclosure: I'm the maintainer of gate.cat, so this is a self-submission. It's an early, open-source (Apache-2.0) project, so I kept the entry strictly factual and non-hyperbolic and appended it at the end of the section.

**What it is:** a deterministic, fail-closed action veto for AI coding agents. It blocks irreversible shell commands (`rm -rf`, `DROP TABLE`, `terraform destroy`, secret exfiltration) before they run, with no LLM in the veto path (so a prompt injection can't talk it into allowing something). Three integration modes: a Claude Code PreToolUse hook, a gated shell for any CLI agent, or a local OpenAI-API proxy.

Repo: https://github.com/BGMLAI/gate.cat · `pip install gate.cat` · https://gate.cat

Follows the CONTRIBUTING.md format (`- **[Tool](URL)** - Description.`), appended at the end of the Runtime Protection section (not alphabetized).

Happy to adjust wording or placement to match your conventions.