### PR TITLE
Add IntentProof agent firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[IntentProof](https://github.com/FeeeeelixWong/intent-proof)** - A local-first runtime guardrail for AI-agent-proposed Solana transfers that enforces recipient and spend policies before wallet signing and generates tamper-evident action receipts.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds [IntentProof](https://github.com/FeeeeelixWong/intent-proof) to Agent Firewalls & Gateways.

IntentProof is an MIT-licensed, actively maintained, local-first runtime guardrail for AI-agent-proposed Solana transfers. It evaluates deterministic recipient, per-action, daily-budget, and intent-evidence policies before Phantom is asked to sign. It also exports SHA-256-linked receipts for allowed and blocked decisions.

The repository includes working code, a hosted Devnet demo, automated tests and CI, documentation, and no token promotion.
