### PR TITLE
Add VERITAS Omega Agent Trust Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Resources to evaluate agent security performance.*
 
 - **[CVE Bench](https://github.com/uiuc-kang-lab/cve-bench)** - A benchmark for evaluating an AI agent's ability to exploit real-world web application vulnerabilities (useful for testing defensive agents).
+- **[VERITAS Omega Agent Trust Lab](https://github.com/VrtxOmega/veritas-agent-trust-lab)** - A browser-based reference lab with six blinded clean/tampered cases for forged verdicts, parameter swaps, nonce replay, correlated evaluators, removed evidence, and silent monitoring; results never authorize execution.
 
 ## 🆔 Identity & Authentication
 *Tools to manage agent identity (non-human identities).*


### PR DESCRIPTION
## Summary

Add one maintained open-source reference lab to **Benchmarks & Datasets** using the repository's required one-line format.

## Why it fits

The list accepts open-source resources directly related to autonomous-agent security and specifically includes resources for evaluating agent security. The Trust Lab presents six blinded clean/tampered pre-action assurance cases and keeps execution authorization fixed to false.

## Validation

- `git diff --check`
- Before: searched the README and all open/closed PRs; no existing VERITAS or Agent Trust Lab entry was present.
- After: the diff contains exactly one Benchmarks & Datasets entry and no other file change.
- I manually verified the repository and live lab return HTTP 200 and reviewed every description claim against the public project README.
- Documentation-only change; no code or generated assets changed.

## Risk

Low. One removable list entry; no source, dependency, or build changes.

Assisted-by: OpenAI Codex
