### PR TITLE
Add SkillSignal to static analysis tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
 - **[ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules)** - 108 open-source regex detection rules for AI agent threats (prompt injection, tool poisoning, credential exfiltration, skill compromise). <1ms per scan. Adopted by Cisco AI Defense.
+- **[SkillSignal](https://skillsignal.cc/)** - An open-source Agent Skills directory that traces exact source files and pinned commits and surfaces deterministic network, script, file, and data-transfer indicators for review before installation.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
Adds SkillSignal as a neutral entry in the Static Analysis & Linters section. The listing focuses on its source-traceability and deterministic review indicators.

Disclosure: I built SkillSignal. The project is free and open-source: https://github.com/wwqking/skillsignal