### PR TITLE
Update Prismor entry (renamed from immunity-agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
-- **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[Prismor](https://github.com/PrismorSec/prismor)** - Self-hosted runtime control plane for AI coding agents. Hooks into Claude Code, Codex, and other agent SDKs to block dangerous commands, secret leaks, and prompt injection before they execute.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
## What this changes

Updates the existing entry in **🛡️ Agent Firewalls & Gateways (Runtime Protection)**, added in #36.

The `PrismorSec/immunity-agent` repo was renamed to `PrismorSec/prismor`. The old link still redirects, but the name and description in the list are stale, so this swaps in the current name, canonical URL, and an accurate one-line description of what the tool does today.

- Before: `Immunity Agent` → `github.com/PrismorSec/immunity-agent`
- After: `Prismor` → `github.com/PrismorSec/prismor`

No new entry added, no section change — just keeping the existing one accurate.