### PR TITLE
Add agentcheck to Guardrails & Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
+- **[agentcheck](https://github.com/uchit/agentcheck)** - Produces an audit evidence pack for an agent deployment across ten controls (workload identity, tool authorisation, autonomy levels, trajectory, blast radius, reversibility, injection defence, provenance, cost per outcome). Reports human-attested and command-verified controls separately rather than as a single score, and exits non-zero when a control is claimed without evidence or rests on an unmet prerequisite, so it works as a CI gate. `npx @uchit/agentcheck`.
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
Adds `agentcheck`, a zero-dependency CLI that produces an audit evidence pack for an agent deployment.

**A note on placement.** This section is described as *middleware to enforce business logic and safety policies on inputs and outputs*, and agentcheck is not middleware — it is an assessment tool that runs against a deployment rather than sitting in the request path. I put it here because "Compliance" is in the section title and nothing else fit better, but if you would rather it went elsewhere, or warranted a separate *Assessment & Evidence* section, I am happy either way. Say the word and I will move it.

**What it does differently.** It refuses to produce a score. Most controls for agentic systems can only be attested by a person, and a tool that quietly converts an attestation into a measurement launders an opinion into evidence. So it reports two counts and never sums them:

- **DECLARED** — a human asserted it, with a name attached
- **VERIFIED** — a read-only command ran, with its output in the report

A command that runs and *fails* counts as neither. There is a test asserting the output object exposes no aggregate score field, so the one design promise cannot regress quietly.

**Why it works as a CI gate.** It exits non-zero only when a pack is indefensible — a control claimed met with no evidence recorded, or claimed met while one of its prerequisites is not met (tool authorisation cannot be met if the agent has no identity of its own to authorise). An honest `unknown` passes, because unknown is the correct starting state and a tool that punishes it teaches people to guess.

**Against the contribution criteria**

- Directly related to agent security: covers OWASP LLM01 (indirect prompt injection through retrieval and tool-result paths) and LLM06 (excessive agency — tool authorisation outside the model, bounded blast radius, action reversibility)
- Open source: MIT. Control set published separately under CC BY 4.0
- Maintained: first release today; CI green on Node 18/20/22/24, 19 tests, zero dependencies
- Not a duplicate: checked, no existing entry

Disclosure: I am the author.

npm: https://www.npmjs.com/package/@uchit/agentcheck
Docs: https://hellouchit.com/agents/