### PR TITLE
Add PolicyStrata

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
+- **[PolicyStrata](https://github.com/raintree-technology/policystrata)** - Deterministic regression tests for policy drift across agent tools, semantic validation, SQL compilation, database controls, and result release.
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
## Summary

- add [PolicyStrata](https://github.com/raintree-technology/policystrata) to Guardrails & Compliance
- describe it as deterministic cross-layer policy regression testing

## Why

PolicyStrata is an MIT-licensed, local-first project for deterministic policy regression testing in LLM data-agent stacks. It checks policy responsibilities across model-visible tools, semantic validation, SQL compilation, database controls, and result release.

I maintain PolicyStrata and am disclosing that relationship with this submission.

## Checks

- `git diff --check`
- verified the repository link and entry format