### PR TITLE
Add ChangeSafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails)** - NVIDIA's toolkit for adding programmable rails to LLM-based apps. It ensures agents stay on topic, avoid jailbreaks, and adhere to defined safety policies.
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
+- **[ChangeSafe](https://github.com/wonkwonlee/ChangeSafe)** - Deterministic policy gate for AI-proposed infrastructure changes; validates Terraform, Kubernetes, and network proposals without granting execution authority.
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
 


### PR DESCRIPTION
## Summary

Adds ChangeSafe to **Guardrails & Compliance**.

ChangeSafe is an open-source deterministic policy gate for infrastructure changes proposed by AI agents. It treats agent proposals as untrusted data and evaluates Terraform plans, Kubernetes changes, and network proposals without executing infrastructure changes.

Disclosure: I maintain ChangeSafe.

## Checks

- Confirmed ChangeSafe is not already listed.
- Added a single entry using the repository's existing format.
- `git diff --check` passes.
