### PR TITLE
Add LintLang to Static Analysis & Linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
 - **[ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules)** - 108 open-source regex detection rules for AI agent threats (prompt injection, tool poisoning, credential exfiltration, skill compromise). <1ms per scan. Adopted by Cisco AI Defense.
+- **[LintLang](https://github.com/hermes-labs-ai/lintlang)** - Deterministic local static analysis for authored natural-language agent instructions.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
Adds LintLang to **Static Analysis & Linters** using the repository's required entry format. The copy is limited to deterministic local static analysis for authored natural-language agent instructions and does not present LintLang as a complete security scanner or runtime guard.

Validation: `git diff --check` passes.
