### PR TITLE
Add BPL-v1.0 to Benchmarks & Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*
 
+- **[BPL-v1.0](https://github.com/clayseal/bpl-benchmark)** - Composite business-policy benchmark for LLM agents: multi-step tool use against policies that no single in-schema call violates. Programmatic oracles; reports V / P / U.
 - **[CVE Bench](https://github.com/uiuc-kang-lab/cve-bench)** - A benchmark for evaluating an AI agent's ability to exploit real-world web application vulnerabilities (useful for testing defensive agents).
 
 ## 🆔 Identity & Authentication


### PR DESCRIPTION
Adds [BPL-v1.0](https://github.com/clayseal/bpl-benchmark) to the Benchmarks & Datasets section.

Composite business-policy eval for LLM tool-using agents (frozen Core-12 / Hard-24, programmatic oracles). MIT, public repo.


Made with [Cursor](https://cursor.com)