### PR TITLE
Add SandBase Harness sandbox runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Secure runtimes to prevent agents from damaging the host system during code execution.*
 
 - **[SandboxAI](https://github.com/substratusai/sandboxai)** - An open-source runtime for executing AI-generated code (Python/Shell) in isolated containers with granular permission controls.
+- **[SandBase Harness](https://github.com/sandbaseai/sandbase-harness)** - A self-hosted agent runtime that runs generated code in per-session Docker or Kubernetes sandboxes and combines them with tool permission policies, approvals, credential vaults, and auditable session replay; its local backend is documented for trusted development.
 - **[Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)** - A Kubernetes Native project providing a Sandbox Custom Resource Definition (CRD) to manage isolated, stateful workloads for AI agents.
 - **[Agent-Infra Sandbox](https://github.com/agent-infra/sandbox)** - An "All-In-One" sandbox combining Browser, Shell, VSCode, and File System access in a single Docker container, optimized for agentic tasks.
 - **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** - Formerly OpenDevin, this platform includes a secure runtime environment for autonomous coding agents to operate without accessing the host machine's sensitive files.


### PR DESCRIPTION
## Summary

Add [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) to **Sandboxing & Isolation Environments**.

The entry describes its documented per-session Docker and Kubernetes sandbox backends together with the permission, approval, credential-vault, and audit/replay controls that surround agent execution. It also preserves the documented boundary that the local backend is for trusted development.

## Checklist

- Directly related to autonomous-agent runtime security
- Apache-2.0 licensed and actively maintained
- Checked for an existing entry and prior SandBase PRs
- `git diff --check` passes

## Disclosure

I contribute to the SandBase project.