### PR TITLE
Add AgentGate to Identity & Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
 - **[OneCLI](https://github.com/onecli/onecli)** - Open-source credential vault for AI agents. A Rust HTTP gateway intercepts agent requests and injects API credentials transparently, so agents never handle raw keys. Supports per-agent scoped tokens and AES-256-GCM encryption at rest.
+- **[AgentGate](https://github.com/Clawdlinux/agentgate)** - Go gateway that proxies agent calls to SaaS APIs so agents never see OAuth tokens. Biscuit tokens scope each agent to a specific principal/service/action, and every action commits a hash-chained, Ed25519-signed receipt verifiable offline with no shared secret.
 
 ---
 


### PR DESCRIPTION
Adds AgentGate to the **Identity & Authentication** section, alongside the existing WSO2/OneCLI entries.

[AgentGate](https://github.com/Clawdlinux/agentgate) is a thin Go gateway that lets AI agents call SaaS APIs (GitHub, Slack, Google Workspace, Stripe) on a user's behalf without ever seeing OAuth tokens. Biscuit tokens attenuate delegation to a specific agent/principal/service/action, and every action commits a hash-chained, Ed25519-signed receipt that anyone can verify offline (`agentgate-verify`) with no shared secret and no gateway state — a non-human-identity credential vault plus a verifiable audit trail for agent actions.

Open source (Apache 2.0), active commits, v0.1.1 tagged and released.