### PR TITLE
Add Bounded Agents to Identity & Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 
 - **[WSO2](https://github.com/wso2)** - An identity management solution that treats AI agents as first-class identities, enabling secure authentication and authorization for agent actions.
 - **[OneCLI](https://github.com/onecli/onecli)** - Open-source credential vault for AI agents. A Rust HTTP gateway intercepts agent requests and injects API credentials transparently, so agents never handle raw keys. Supports per-agent scoped tokens and AES-256-GCM encryption at rest.
+- **[Bounded Agents](https://github.com/xmuruaga/bounded-agents)** - Reference implementation of the Agentic Principal Chain (APC), an authorization architecture that narrows delegated authority across multi-agent chains and blocks prohibited compositions of individually permitted actions. See the [paper](https://arxiv.org/abs/2608.15888).
 
 ---
 


### PR DESCRIPTION
Adds Bounded Agents to Identity & Authentication. The open reference implementation narrows delegated authority across multi-agent chains and prevents prohibited compositions of individually permitted actions; the entry links both the implementation and the paper. Validation: git diff --check and markdownlint.