### PR TITLE
Add SkillTotal to Static Analysis & Linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
 - **[ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules)** - 108 open-source regex detection rules for AI agent threats (prompt injection, tool poisoning, credential exfiltration, skill compromise). <1ms per scan. Adopted by Cisco AI Defense.
+- **[SkillTotal](https://github.com/pezhik/skilltotal)** - Static security scanner for AI components: agent skills and plugins, MCP servers, npm/PyPI packages and repos. Deterministic regex + AST that never executes the component and calls no LLM, so scans run offline and reproduce exactly; flags MCP tool poisoning and shadowing, prompt-injection surfaces and exfiltration paths, with file/line evidence behind every finding and SARIF output for CI.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
Adds [SkillTotal](https://github.com/pezhik/skilltotal) under **Static Analysis & Linters**.

Static security scanner for AI components — agent skills and plugins, MCP servers, npm/PyPI packages and repos. Detection is deterministic regex + AST: the component is never executed and no LLM is involved, so a scan runs fully offline, needs no account, and reproduces exactly. It flags MCP tool poisoning and shadowing, prompt-injection surfaces and exfiltration paths, and every finding carries file/line evidence rather than a bare verdict. Output is JSON and SARIF 2.1.0, with a GitHub Action and a pre-commit hook.

Against the guidelines:
- **Relevance** — the analysed artefacts are the agent's own supply chain: skills, plugins and MCP servers.
- **Open source** — Apache-2.0, zero runtime dependencies, no paid tier needed for any rule.
- **Maintenance** — active; latest release v0.42.0 (2026-08-21).
- **Not already listed** — checked the section.

If it fits better elsewhere, or you'd like the entry shortened to match the surrounding style, happy to change it.