### PR TITLE
Add decision-os-min to Agent Firewalls & Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 *Tools that sit between the agent and the world to filter traffic, prevent unauthorized tool access, and block prompt injections.*
 
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
+- **[decision-os-min](https://github.com/Aliipou/decision-os-min)** - Python runtime between an agent and its effects: Ed25519-signed action-bound decisions, one-time capability spend, and a PEP that will not run the tool without both. OPA/Cedar stay replaceable PDPs. PolyForm-Noncommercial-1.0.0.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
 


### PR DESCRIPTION
Add decision-os-min to Agent Firewalls & Gateways (Runtime Protection).

It sits between an agent and its effects: signed action-bound decision + one-time capability spend + PEP refuse. Not a prompt-injection scanner and not a Cedar/OPA replacement.

Author disclosure: I am the author. License is PolyForm Noncommercial 1.0.0 (source-available, not OSI) — reject if this list is OSI-only. Description is factual.
