### PR TITLE
Add HOL Guard to Agent Firewalls & Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[HOL Guard](https://hol.org/guard)** - Open-source local-first runtime security layer for AI agents that evaluates supported tool actions and local artifacts for prompt injection, secret exposure, unsafe commands, package risks, and MCP threats.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds HOL Guard to **Agent Firewalls & Gateways (Runtime Protection)** using the repository's documented one-line format.

HOL Guard is an open-source local-first runtime security layer for AI agents. The entry is limited to documented behavior: evaluation of supported tool actions and local artifacts for prompt injection, secret exposure, unsafe commands, package risks, and MCP threats.

Source: https://github.com/hashgraph-online/hol-guard
Canonical project page: https://hol.org/guard
License: Apache-2.0

**Disclosure:** I am President of HOL / Hashgraph Online and am materially affiliated with the project.