### PR TITLE
Add Mneme — architectural drift prevention guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
+- **[Mneme](https://github.com/MnemeHQ/mneme)** - Architectural drift prevention for the AI SDLC; deterministic guardrails that verify AI coding-agent changes against declared architecture (ADRs) before merge.
+
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
Adds [Mneme](https://github.com/MnemeHQ/mneme) under **Guardrails & Compliance**. Deterministic pre-action verification of AI coding-agent changes against declared architecture (ADRs). Evidence: [hook implementation](https://github.com/MnemeHQ/mneme/blob/main/mneme/integrations/claude_code/hook.py) + [integration tests](https://github.com/MnemeHQ/mneme/tree/main/tests/integrations) + [Paperclip compat report](https://github.com/MnemeHQ/mneme/blob/main/docs/validation/paperclip-compat-report.md).