### PR TITLE
Add xihu-sword-ctf-agent to Red Teaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Garak](https://github.com/leondz/garak)** - The "Nmap for LLMs." A vulnerability scanner that probes models for hallucination, data leakage, and prompt injection susceptibilities.
 - **[A2A Scanner](https://github.com/cisco-ai-defense/a2a-scanner)** - A scanner by Cisco designed to inspect "Agent-to-Agent" communication protocols for threats, validating agent identities and ensuring compliance with communication specs.
 - **[Cybersecurity AI (CAI)](https://github.com/aliasrobotics/cai)** - A framework for building specialized security agents for offensive and defensive operations, often used in CTF (Capture The Flag) scenarios.
+- **[xihu-sword-ctf-agent](https://github.com/truefurina/xihu-sword-ctf-agent)** - A deterministic-first multi-agent framework for solving CTF challenges. It fans out a `presolve` static-analysis layer (49 deterministic skills across crypto/misc/web/reverse/pwn) and escalates to an LLM only on cache misses, with fail-closed submission gating, budget guardrails, and an explicit "honesty ledger" that reports static-analysis coverage vs. LLM reasoning separately.
 
 ## 🔍 Static Analysis & Linters
 *Tools to analyze agent configuration and logic code before deployment.*


### PR DESCRIPTION
Adds [xihu-sword-ctf-agent](https://github.com/truefurina/xihu-sword-ctf-agent) to the **Red Teaming & Vulnerability Scanners** section.

- Deterministic-first multi-agent CTF solving framework: a `presolve` static-analysis layer (49 deterministic skills across crypto/misc/web/reverse/pwn) runs first, escalating to an LLM only on cache misses.
- Fail-closed submission gating, budget guardrails, and an explicit "honesty ledger" that reports static-analysis coverage vs. LLM reasoning separately.
- Fits naturally alongside `CAI`, which is also CTF-oriented.

Self-check against CONTRIBUTING: single-entry addition, no broken links, description follows the existing `- **[Name](url)** - desc.` format. Not a fork/spam — it is an original, MIT-licensed project.