### PR TITLE
Add whatileaked to Static Analysis & Linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
 - **[ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules)** - 108 open-source regex detection rules for AI agent threats (prompt injection, tool poisoning, credential exfiltration, skill compromise). <1ms per scan. Adopted by Cisco AI Defense.
+- **[whatileaked](https://github.com/selan-ai/whatileaked)** - A local scanner for credentials a coding agent has already written to disk: Claude Code, Codex and Cursor transcripts plus instruction/memory files (CLAUDE.md, AGENTS.md) that are re-read every session. Uses the gitleaks rule set, reports a rule name and one-way fingerprint instead of the secret, and redacts findings in place. No network calls, no telemetry, zero dependencies.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
Adds whatileaked, which scans what a coding agent has already written to local disk.

Transcripts (Claude Code, Codex, Cursor) hold credentials that were already sent to a model provider. Instruction and memory files (CLAUDE.md, AGENTS.md) are the sharper case, because the agent re-reads them at the start of every session, so a credential there keeps leaking until someone edits the file. Both are scanned, and `wipe` redacts findings in place while keeping the files valid.

Detection uses the gitleaks rule set unmodified. It never prints a credential, only a rule name and a one-way fingerprint, so output is safe to paste into an issue. No network request, zero dependencies, MIT.

Sits next to Aguara in this section: Aguara analyses skill and MCP configs before deployment, this one looks at the history the agent left behind afterwards.

Disclosure: I wrote it. We also sell a proxy that redacts credentials before they leave the machine, so the scanner is standalone and dependency-free on purpose, to make it auditable.