### PR TITLE
docs: add SandBase Harness sandbox runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[SandboxAI](https://github.com/substratusai/sandboxai)** - An open-source runtime for executing AI-generated code (Python/Shell) in isolated containers with granular permission controls.
 - **[Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox)** - A Kubernetes Native project providing a Sandbox Custom Resource Definition (CRD) to manage isolated, stateful workloads for AI agents.
 - **[Agent-Infra Sandbox](https://github.com/agent-infra/sandbox)** - An "All-In-One" sandbox combining Browser, Shell, VSCode, and File System access in a single Docker container, optimized for agentic tasks.
+- **[SandBase Harness](https://github.com/sandbaseai/sandbase-harness)** - A local-first agent runtime with governed tool access, credential management, approval workflows, sandboxed sessions, and audit/replay across local, Docker, Kubernetes, and self-hosted worker backends.
 - **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** - Formerly OpenDevin, this platform includes a secure runtime environment for autonomous coding agents to operate without accessing the host machine's sensitive files.
 
 ## 🚧 Guardrails & Compliance


### PR DESCRIPTION
## Summary\n- add SandBase Harness to Sandboxing & Isolation Environments\n- describe governed tool access, credentials, approvals, audit/replay, and supported execution backends\n\n## Verification\n- SandBase Harness is open source and actively maintained\n- official project: https://github.com/sandbaseai/sandbase-harness\n- installation: https://github.com/sandbaseai/sandbase-harness/blob/main/README.md#installation\n- sandbox backends: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/sandboxing.md\n- latest release: https://github.com/sandbaseai/sandbase-harness/releases/latest\n\nThe entry describes capabilities without claiming a universal isolation boundary or security certification.