### PR TITLE
Add skillock

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Agent Bound](https://github.com/ElPaisano/agent-bound)** - A design-time analysis tool that calculates "Agentic Entropy"—a metric to quantify the unpredictability and risk of infinite loops or unconstrained actions in agent architectures.
 - **[Checkov](https://github.com/bridgecrewio/checkov)** - While primarily for IaC, Checkov includes policies for scanning AI infrastructure and configurations to prevent misconfigurations in deployment.
 - **[ATR (Agent Threat Rules)](https://github.com/Agent-Threat-Rule/agent-threat-rules)** - 108 open-source regex detection rules for AI agent threats (prompt injection, tool poisoning, credential exfiltration, skill compromise). <1ms per scan. Adopted by Cisco AI Defense.
+- **[skillock](https://github.com/ruslanlap/skillock)** - Security-first package manager for AI agent skills. Scans before install, blocks risky instructions, and writes a lockfile with pinned refs and SHA-256 hashes for Claude Code, Codex, Cursor, and Hermes.
 
 ## 📦 Sandboxing & Isolation Environments
 *Secure runtimes to prevent agents from damaging the host system during code execution.*


### PR DESCRIPTION
Adds skillock under **Static Analysis & Linters**.

Why it fits:
- scans AI agent skills before installation
- blocks risky instructions (secret reads, code execution patterns)
- pins refs and SHA-256 hashes in a lockfile for repeatable installs

Repo: https://github.com/ruslanlap/skillock
