### PR TITLE
Add sofagent to Guardrails & Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[Guardrails](https://github.com/guardrails-ai/guardrails)** - A Python framework for validating LLM outputs against structural and semantic rules (e.g., "must return valid JSON," "must not contain PII").
 - **[LiteLLM Guardrails](https://github.com/BerriAI/litellm)** - While known for model proxying, LiteLLM includes built-in guardrail features to filter requests and responses across multiple LLM providers.
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - An official OWASP project that detects and blocks AI agent memory poisoning attacks (OWASP ASI06). Provides a drop-in middleware for LangChain, AutoGen, and CrewAI pipelines with real-time threat detection, sanitization hooks, and audit logging. `pip install agent-memory-guard`.
+- **[sofagent](https://github.com/KongFangXun/sofagent)** - Open-source harness for governing AI coding agents: 24 commit-time audit rules over git diffs (secrets, out-of-scope edits, prompt injection) with HMAC-signed audit trail and snapshot rollback; MCP server with 79 tools; enforces policies at commit time via git hooks, runtime-agnostic.
 
 ## 📊 Benchmarks & Datasets
 *Resources to evaluate agent security performance.*


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **Guardrails & Compliance** section (section tail, following the existing entry format).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is an open-source harness for governing AI coding agents: 24 commit-time audit rules over git diffs (secrets, out-of-scope edits, blind modifications, prompt injection), HMAC-signed tamper-evident audit trail, snapshot rollback, and an MCP server with 79 tools. It enforces policies at commit time via git hooks, so it works with any agent runtime.

Related listings: [punkpeye/awesome-mcp-servers #13312](https://github.com/punkpeye/awesome-mcp-servers/pull/13312), [agentrust-io/awesome-ai-governance #89](https://github.com/agentrust-io/awesome-ai-governance/pull/89), [ai-boost/awesome-harness-engineering #227](https://github.com/ai-boost/awesome-harness-engineering/pull/227).

Single-line change to README.md only.