### PR TITLE
Add Helio to Agent Firewalls & Gateways section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is organized by the **security lifecycle** of an autonomous agent, cov
 - **[AgentGateway](https://github.com/agentgateway/agentgateway)** - A Linux Foundation project providing an AI-native proxy for secure connectivity (A2A & MCP protocols). It adds RBAC, observability, and policy enforcement to agent-tool interactions.
 - **[Envoy AI Gateway](https://gateway.envoyproxy.io/)** - An Envoy-based gateway that manages request traffic to GenAI services, providing a control point for rate limiting and policy enforcement.
 - **[Immunity Agent](https://github.com/PrismorSec/immunity-agent)** - Security-focused AI agent runtime for scanning prompt injection, MCP risks, unsafe package installs, and dangerous agent actions before execution.
+- **[Helio](https://github.com/gethelio/helio)** - An MCP governance proxy that sits between agents and the tools they call, enforcing per-tool policies, human approval gates, and cumulative cross-tool spend caps before a request reaches the server. Every decision and outcome is written to an audit trail, with no changes to agent code or MCP servers.
 
 ## ⚔️ Red Teaming & Vulnerability Scanners
 *Offensive tools to test agents for security flaws, loop conditions, and unauthorized actions.*


### PR DESCRIPTION
Adds [Helio](https://github.com/gethelio/helio) to Agent Firewalls & Gateways (Runtime Protection).

Helio is an Apache-2.0 proxy that sits between MCP clients and MCP servers. Every tool call is evaluated against declarative policies before it reaches the server, irreversible actions can be routed to a human approval gate, cumulative spend is capped across tools, and the decision and outcome are recorded in an audit trail. The agent and the MCP servers are unmodified, so it drops in front of an existing setup.

Against the contributing guidelines:

- Relevance: runtime protection. It sits between the agent and the world and gates unauthorized tool access on the live call path.
- Open source: Apache-2.0, installed with `npx @gethelio/proxy init`. No paid tier is needed to run it.
- Maintenance: most recent release v0.13.0, last commit 31 August 2026.
- Searched the list first; Helio is not currently present.

The entry follows the format in CONTRIBUTING.md and is appended to the end of the section, matching where the recently merged entries landed. The diff is one added line.
